### PR TITLE
Identity compute service by type instead of name

### DIFF
--- a/api_fetch.go
+++ b/api_fetch.go
@@ -6,7 +6,7 @@ import(
 
 //The default generic openstack api
 var OpenstackApi = map[string]interface{}{
-        "Name":      "nova",
+        "Type":      "compute",
 	"UrlChoice": PublicURL,
 }
 


### PR DESCRIPTION
I understand this fork is probably not meant for active development, but there's a bug here that prevents packer's OpenStack builder from working with some private OpenStack deployments, HP's public cloud, and likely others. This bug has been fixed in the current version of gophercloud (see https://github.com/rackspace/gophercloud/pull/179 for the bug fix and discussion). This commit won't be needed once packer is updated to the latest version of gophercloud.

Instead of identifying the compute service by looking for a service named "nova", we should look for a service with the type "compute". The name of a service is configurable and may vary between OpenStack deployments, but the type should always be "compute". This behavior would match the strategy used by python-novaclient, the reference implementation for OpenStack clients (see [here](https://github.com/openstack/python-novaclient/blob/0f7bf493887b11ccc811b8e93e59d7b3993263c7/novaclient/client.py#L715) and [here](https://github.com/openstack/python-novaclient/blob/0f7bf493887b11ccc811b8e93e59d7b3993263c7/novaclient/shell.py#L66)).

This _theoretically_ could break people using packer if they configured their OpenStack deployment to have more than one "compute" services and were relying on packer using the one called "nova", or if they configured their compute service to have a type other than "compute", but in these cases the standard nova client wouldn't work with their configuration, so I think the likelihood of this occurring is pretty low.
